### PR TITLE
Fixed bug in finding svgs in subdirectories

### DIFF
--- a/src/helpers/getSvgsInDir.js
+++ b/src/helpers/getSvgsInDir.js
@@ -9,14 +9,15 @@ const getSvgsInDir = (dir) => {
         .map((file) => {
             const absolutePath = path.join(dir, file);
             if (fs.lstatSync(absolutePath).isDirectory()) {
-                return getSvgsInDir(dir, file);
+                return getSvgsInDir(absolutePath);
             }
             if (!absolutePath.match(/\.svg$/)) {
                 return null;
             }
             return absolutePath;
         })
-        .filter(filePath => filePath !== null);
+        .filter(filePath => filePath !== null)
+        .reduce((a, b) => a.concat(b), []);
 };
 
 module.exports = getSvgsInDir;


### PR DESCRIPTION
The generator crashed when there were subdirectories in the svgDir. Seems it called getSvgsInDir with the same directory over and over, eventually causing and overflow. Also, since the resulting array now contains multiple levels of filenames, I added a reduce function to flatten them. As far as I can tell, this has fixed the problem, and it now works to have svgs in subdirectories.
